### PR TITLE
Chore/#65 : 타이포그래피 CSS 변수 및 유틸리티 클래스 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,7 +62,7 @@
 
   /* 브레이크포인트 */
   --breakpoint-tablet: 744px;
-  --breakpoint-desktop: 1920px;
+  --breakpoint-desktop: 1280px;
 
   /* 폰트 굵기 */
   --font-weight-regular: 400;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #65

## 📝 작업 내용

  - `@theme`에 font-size, line-height 변수 정의
  - `@layer utilities`에 타이포그래피 클래스 추가 (font-size, line-height, letter-spacing 한번에 적용)
  - Tailwind v4에서 `--text-*--letter-spacing` 미지원으로 `@layer utilities`로 자간까지 묶어서 처리

### 사용법

  ```tsx
  // 기존 방식 (불편)
  <p className="text-display-1 tracking-[-0.00179em]">텍스트</p>

  // 개선된 방식
  <p className="typography-display-1">텍스트</p>
  <p className="typography-body-1 font-bold">텍스트</p>
  <p className="typography-label-1 font-medium">텍스트</p>
```

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> Tailwind v4에서 --text-*--letter-spacing 형식으로 자간 설정이 지원이 안 돼서 @layer utilities로 font-size,
  line-height, letter-spacing을 하나의 클래스로 묶어서 해결했습니다
