### PR TITLE
Feat/#97 팀 관리자 페이지 UI 구현

### DIFF
--- a/src/app/taskmate/team/management/page.tsx
+++ b/src/app/taskmate/team/management/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import TextButton from "@/components/common/TextButton/TextButton";
+import InviteModal from "@/components/management/InviteModal";
+import MemberList from "@/components/management/MemberList";
+import TeamNameEditor from "@/components/management/TeamNameEditor";
+import { useOverlay } from "@/hooks/useOverlay";
+
+const TeamManagement = () => {
+  const { open, close } = useOverlay();
+
+  const handleOpenInvite = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+
+    open(
+      "invite-modal",
+      <InviteModal
+        onClose={() => {
+          close();
+        }}
+      />,
+    );
+  };
+
+  return (
+    <main className="relative my-20 flex w-full flex-col items-center gap-6">
+      <div className="relative flex flex-col gap-6">
+        <h1 className="typography-title-3">팀 정보 수정</h1>
+        <div className="flex w-140 flex-col gap-6">
+          <TeamNameEditor />
+          <MemberList onInviteClick={handleOpenInvite} />
+
+          <TextButton className="ml-auto w-fit">팀 삭제하기</TextButton>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default TeamManagement;

--- a/src/components/management/InviteModal.tsx
+++ b/src/components/management/InviteModal.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import Button from "@/components/common/Button/Button";
+import Input from "@/components/common/Input/Input";
+
+interface InviteModalProps {
+  onClose: () => void;
+}
+
+const InviteModal = ({ onClose }: InviteModalProps) => {
+  const [email, setEmail] = useState("");
+
+  useEffect(() => {
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = prevOverflow;
+    };
+  }, []);
+
+  const handleInvite = () => {
+    onClose();
+  };
+
+  return (
+    <section className="fixed inset-0 z-9999 flex items-center justify-center bg-black/30 backdrop-blur-sm">
+      <div className="relative flex w-112.5 flex-col gap-8 rounded-2xl bg-white p-8 shadow-lg">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-3 w-fit cursor-pointer self-end text-2xl"
+        >
+          x
+        </button>
+        <h2>팀원 초대</h2>
+
+        <Input
+          placeholder="초대하실 분의 이메일을 입력해주세요."
+          className="rounded-4 border border-gray-200 p-4"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+
+        <Button
+          type="submit"
+          className="ml-auto w-fit rounded-xl"
+          onClick={handleInvite}
+        >
+          초대하기
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default InviteModal;

--- a/src/components/management/MemberList.tsx
+++ b/src/components/management/MemberList.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Button from "@/components/common/Button/Button";
+
+interface MemberListProps {
+  onInviteClick: () => void;
+}
+
+const MemberList = ({ onInviteClick }: MemberListProps) => {
+  return (
+    <section className="bg-inverse-normal relative h-183.25 rounded-4xl">
+      <div
+        className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-[90px] rounded-b-4xl"
+        style={{
+          background:
+            "linear-gradient(to top, rgba(255,255,255,1) 0%, rgba(255,255,255,0.8) 45%, rgba(255,255,255,0) 100%)",
+        }}
+      />
+      <Button
+        className="absolute right-5 bottom-5.75 z-20"
+        type="button"
+        onClick={onInviteClick}
+      >
+        팀원 추가하기
+      </Button>
+    </section>
+  );
+};
+
+export default MemberList;

--- a/src/components/management/TeamNameEditor.tsx
+++ b/src/components/management/TeamNameEditor.tsx
@@ -1,0 +1,33 @@
+"use client";
+// React
+import { useState } from "react";
+
+import Button from "@/components/common/Button/Button";
+// 내부
+import Input from "@/components/common/Input/Input";
+
+const TeamNameEditor = () => {
+  const [value, setValue] = useState("");
+
+  return (
+    <section className="bg-background-normal flex h-[186px] w-full flex-col gap-2 rounded-[32px] px-6 pt-6 pb-5">
+      <h2 className="typography-body-2">팀명</h2>
+      <form className="flex flex-col gap-3">
+        <Input
+          placeholder="팀명"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+
+        <Button
+          type="submit"
+          className="ml-auto w-fit rounded-xl"
+        >
+          저장하기
+        </Button>
+      </form>
+    </section>
+  );
+};
+
+export default TeamNameEditor;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #97 

## 📝 작업 내용

> 팀 관리자 페이지 UI 구현

### 스크린샷 (선택)
<img width="1125" height="553" alt="스크린샷 2026-03-29 오후 6 51 26" src="https://github.com/user-attachments/assets/167ed222-6e01-4848-a39f-3a97ca0e75b7" />

