### PR TITLE
Feat/#84 :  Google OAuth 로그인/회원가입 흐름 구현 

### DIFF
--- a/src/app/api/auth/callback/google/route.ts
+++ b/src/app/api/auth/callback/google/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get("code");
+  const error = searchParams.get("error");
+  const state = searchParams.get("state");
+  const redirectPath = state === "signup" ? "/signup" : "/login";
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+  if (error || !code) {
+    return Response.redirect(
+      `${baseUrl}${redirectPath}?error=${error ?? "unknown"}`,
+    );
+  }
+
+  try {
+    const response = await fetch(
+      `${process.env.BACKEND_URL}/api/auth/google?code=${code}&redirectUri=${baseUrl}/api/auth/callback/google`,
+    );
+    if (!response.ok) {
+      return Response.redirect(`${baseUrl}${redirectPath}?error=oauth_failed`);
+    }
+    const data = await response.json();
+
+    if (!data?.data?.accessToken || !data?.data?.refreshToken) {
+      return Response.redirect(`${baseUrl}${redirectPath}?error=oauth_failed`);
+    }
+
+    const res = NextResponse.redirect(`${baseUrl}/taskmate`);
+    res.cookies.set("accessToken", data.data.accessToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 59,
+    });
+
+    res.cookies.set("refreshToken", data.data.refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 14,
+    });
+
+    return res;
+  } catch {
+    return Response.redirect(`${baseUrl}${redirectPath}?error=oauth_failed`);
+  }
+}

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -1,0 +1,23 @@
+export function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const from = searchParams.get("from");
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+  const clientId = process.env.GOOGLE_CLIENT_ID;
+
+  if (!clientId) {
+    return Response.redirect(`${baseUrl}/login?error=oauth_unavailable`);
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: `${baseUrl}/api/auth/callback/google`,
+    response_type: "code",
+    scope: "email profile",
+    state: from ?? "login",
+  });
+
+  return Response.redirect(
+    `https://accounts.google.com/o/oauth2/v2/auth?${params}`,
+  );
+}

--- a/src/components/auth/Login/LoginForm.tsx
+++ b/src/components/auth/Login/LoginForm.tsx
@@ -1,30 +1,18 @@
 "use client";
 import Link from "next/link";
-import React, { useActionState, useEffect } from "react";
+import React, { useActionState } from "react";
 
 import Button from "@/components/common/Button/Button";
 import { Icon } from "@/components/common/Icon";
 import Input from "@/components/common/Input";
+import { useOAuthError } from "@/features/auth/hooks/useOAuthError";
 import { loginAction } from "@/features/auth/login/actions/loginAction";
 import useLoginForm from "@/features/auth/login/hooks/useLoginForm";
-import { useToast } from "@/hooks/useToast";
 
 const LoginForm = () => {
-  const { values, handleChange, showPassword, togglePassword } = useLoginForm();
+  const { values, showPassword, togglePassword, handleChange } = useLoginForm();
   const [state, formAction] = useActionState(loginAction, null);
-
-  const { toast } = useToast();
-
-  // TODO : 로그인 실패시 토스트처리
-  useEffect(() => {
-    if (state?.errors?.message) {
-      toast({
-        title: state.errors.message,
-        variant: "error",
-      });
-    }
-  }, [state, toast]);
-
+  useOAuthError("login");
   return (
     <>
       <form

--- a/src/components/auth/Signup/SignupForm.tsx
+++ b/src/components/auth/Signup/SignupForm.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import Button from "@/components/common/Button/Button";
 import { Icon } from "@/components/common/Icon";
 import Input from "@/components/common/Input";
+import { useOAuthError } from "@/features/auth/hooks/useOAuthError";
 import useSignupForm from "@/features/auth/signup/hooks/useSignupForm";
 
 // TODO : 이메일 중복 체크 디자인 수정 예정
@@ -22,6 +23,7 @@ const SignupForm = () => {
     handleEmailDuplicate,
     isEmailChecked,
   } = useSignupForm();
+  useOAuthError("signup");
   return (
     <>
       <form

--- a/src/components/auth/SnsLoginButtons/SnsLoginButtons.tsx
+++ b/src/components/auth/SnsLoginButtons/SnsLoginButtons.tsx
@@ -4,7 +4,7 @@ import { AuthFormType } from "@/features/auth/types/auth.type";
 
 const SnsLoginButtons = ({
   label,
-  type: _type,
+  type,
 }: {
   label: string;
   type: AuthFormType;
@@ -19,8 +19,14 @@ const SnsLoginButtons = ({
         <div className="h-px flex-1 bg-gray-200" />
       </div>
       <div className="flex gap-4">
-        <SocialButton social="google" />
-        <SocialButton social="kakao" />
+        <SocialButton
+          social="google"
+          from={type}
+        />
+        {/* <SocialButton
+          social="kakao"
+          from={type}
+        /> */}
       </div>
     </div>
   );

--- a/src/components/common/SocialButton/SocialButton.tsx
+++ b/src/components/common/SocialButton/SocialButton.tsx
@@ -1,9 +1,8 @@
-// React
-import { ComponentPropsWithoutRef } from "react";
+import { ComponentProps } from "react";
 
-// 내부 코드
 import GoogleIcon from "@/components/common/Icons/GoogleIcon";
 import KakaoIcon from "@/components/common/Icons/KakaoIcon";
+import { AuthFormType } from "@/features/auth/types/auth.type";
 import { cn } from "@/utils/utils";
 
 const SOCIAL_CONFIG = {
@@ -19,22 +18,17 @@ const SOCIAL_CONFIG = {
   },
 } as const;
 
-interface SocialButtonProps extends ComponentPropsWithoutRef<"button"> {
+interface SocialButtonProps extends ComponentProps<"a"> {
   social: keyof typeof SOCIAL_CONFIG;
+  from: AuthFormType;
 }
 
-const SocialButton = ({
-  social,
-  className,
-  type = "button",
-  ...props
-}: SocialButtonProps) => {
+const SocialButton = ({ social, className, from }: SocialButtonProps) => {
   const config = SOCIAL_CONFIG[social];
 
   return (
-    <button
-      type={type}
-      {...props}
+    <a
+      href={`/api/auth/${social}?from=${from}`}
       className={cn(
         "relative flex h-14 w-14 shrink-0 items-center justify-center rounded-full transition-opacity focus:outline-none active:opacity-80",
         config.bg,
@@ -43,7 +37,7 @@ const SocialButton = ({
       )}
     >
       {config.icon}
-    </button>
+    </a>
   );
 };
 

--- a/src/features/auth/hooks/useOAuthError/index.ts
+++ b/src/features/auth/hooks/useOAuthError/index.ts
@@ -1,0 +1,1 @@
+export { useOAuthError } from "./useOAuthError";

--- a/src/features/auth/hooks/useOAuthError/useOAuthError.ts
+++ b/src/features/auth/hooks/useOAuthError/useOAuthError.ts
@@ -1,0 +1,25 @@
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+import { useToast } from "@/hooks/useToast";
+
+export function useOAuthError(authType: "login" | "signup") {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    // TODO : 모달로 변경예정
+    const error = searchParams.get("error");
+    const authTypeTitle = authType === "login" ? "로그인" : "회원가입";
+    if (error) {
+      toast({
+        title: `Google ${authTypeTitle}에 실패했어요. 다시 시도해주세요.`,
+        variant: "error",
+      });
+
+      router.replace(pathname);
+    }
+  }, [searchParams, authType, pathname, router, toast]);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>  Closes #84   

## 📝 작업 내용

 - Google OAuth 시작점 route handler 구현 (`/api/auth/google`)                                                                                           
    - `GOOGLE_CLIENT_ID` 미설정 시 에러 처리                                                                                                              
  - Google OAuth 콜백 route handler 구현 (`/api/auth/callback/google`)
    - 인증 성공 시 httpOnly 쿠키로 토큰 저장 후 `/taskmate` redirect                                                                                      
    - 토큰 누락 / 백엔드 오류 / 네트워크 오류 모두 에러 처리                                                                                              
  - `useOAuthError` 훅 구현                                                                                                                               
    - OAuth 실패 시 toast 에러 표시 후 URL 파라미터 제거                                                                                                  
  - `SocialButton` `<button>` → `<a>` 변경, `from` prop 추가                                                                                              
  - `LoginForm`, `SignupForm`, `SnsLoginButtons`에 OAuth 연결            


### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 테스트                                                                                                                                               
  - [ ] Google 로그인 버튼 클릭 → Google 인증 화면 이동                                                                                                   
  - [ ] 인증 성공 → `/taskmate` redirect, 쿠키 설정 확인                                                                                                  
  - [ ] 인증 실패 / 취소 → 로그인 화면으로 돌아오며 toast 표시    ->  modal로 수정예정                                                                                         
  - [ ] 회원가입 화면에서도 동일하게 동작 확인       
