### PR TITLE
Feat/#85 : 카카오 OAuth 로그인/회원가입 흐름 구현 및 OAuth 에러 처리 개선

### DIFF
--- a/src/app/api/auth/callback/kakao/route.ts
+++ b/src/app/api/auth/callback/kakao/route.ts
@@ -11,30 +11,30 @@ export async function GET(request: Request) {
 
   if (error || !code) {
     return Response.redirect(
-      `${baseUrl}${redirectPath}?error=${error ?? "unknown"}&social=google`,
+      `${baseUrl}${redirectPath}?error=${error ?? "unknown"}&social=kakao`,
     );
   }
 
   if (!process.env.BACKEND_URL) {
     return Response.redirect(
-      `${baseUrl}${redirectPath}?error=oauth_failed&social=google`,
+      `${baseUrl}${redirectPath}?error=oauth_failed&social=kakao`,
     );
   }
 
   try {
     const response = await fetch(
-      `${process.env.BACKEND_URL}/api/auth/google?code=${code}&redirectUri=${baseUrl}/api/auth/callback/google`,
+      `${process.env.BACKEND_URL}/api/auth/kakao?code=${code}&redirectUri=${baseUrl}/api/auth/callback/kakao`,
     );
     if (!response.ok) {
       return Response.redirect(
-        `${baseUrl}${redirectPath}?error=oauth_failed&social=google`,
+        `${baseUrl}${redirectPath}?error=oauth_failed&social=kakao`,
       );
     }
     const data = await response.json();
 
     if (!data?.data?.accessToken || !data?.data?.refreshToken) {
       return Response.redirect(
-        `${baseUrl}${redirectPath}?error=oauth_failed&social=google`,
+        `${baseUrl}${redirectPath}?error=oauth_failed&social=kakao`,
       );
     }
 
@@ -56,7 +56,7 @@ export async function GET(request: Request) {
     return res;
   } catch {
     return Response.redirect(
-      `${baseUrl}${redirectPath}?error=oauth_failed&social=google`,
+      `${baseUrl}${redirectPath}?error=oauth_failed&social=kakao`,
     );
   }
 }

--- a/src/app/api/auth/kakao/route.ts
+++ b/src/app/api/auth/kakao/route.ts
@@ -1,0 +1,21 @@
+export function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const from = searchParams.get("from");
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+  const clientId = process.env.KAKAO_CLIENT_ID;
+
+  if (!clientId) {
+    return Response.redirect(`${baseUrl}/login?error=oauth_unavailable`);
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: `${baseUrl}/api/auth/callback/kakao`,
+    response_type: "code",
+    scope: "account_email,profile_nickname",
+    state: from ?? "login",
+  });
+
+  return Response.redirect(`https://kauth.kakao.com/oauth/authorize?${params}`);
+}

--- a/src/components/auth/SnsLoginButtons/SnsLoginButtons.tsx
+++ b/src/components/auth/SnsLoginButtons/SnsLoginButtons.tsx
@@ -23,10 +23,10 @@ const SnsLoginButtons = ({
           social="google"
           from={type}
         />
-        {/* <SocialButton
+        <SocialButton
           social="kakao"
           from={type}
-        /> */}
+        />
       </div>
     </div>
   );

--- a/src/features/auth/hooks/useOAuthError/useOAuthError.ts
+++ b/src/features/auth/hooks/useOAuthError/useOAuthError.ts
@@ -12,10 +12,12 @@ export function useOAuthError(authType: "login" | "signup") {
   useEffect(() => {
     // TODO : 모달로 변경예정
     const error = searchParams.get("error");
+    const social = searchParams.get("social");
+    const socialName = social === "kakao" ? "카카오" : "Google";
     const authTypeTitle = authType === "login" ? "로그인" : "회원가입";
     if (error) {
       toast({
-        title: `Google ${authTypeTitle}에 실패했어요. 다시 시도해주세요.`,
+        title: `${socialName} ${authTypeTitle}에 실패했어요. 다시 시도해주세요.`,
         variant: "error",
       });
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closes #85 

## 📝 작업 내용

- 카카오 OAuth 시작점 route handler 구현 (`/api/auth/kakao`)
- 카카오 OAuth 콜백 route handler 구현 (`/api/auth/callback/kakao`)
- 인증 성공 시 httpOnly 쿠키로 토큰 저장 후 `/taskmate` redirect
    - 토큰 누락 / 백엔드 오류 / 네트워크 오류 모두 에러 처리
    - Google/카카오 콜백에 `BACKEND_URL` 미설정 시 에러 처리 추가
- `useOAuthError` 소셜 종류별 에러 메시지 분기 (Google / 카카오)
- `SnsLoginButtons` 카카오 버튼 활성화     

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 테스트                                                                                                                   
  - [ ] 카카오 로그인 버튼 클릭 → 카카오 인증 화면 이동                                                                       
  - [ ] 인증 성공 → `/taskmate` redirect, 쿠키 설정 확인                                                                      
  - [ ] 인증 실패 / 취소 → "카카오 로그인에 실패했어요" toast 표시                                                            
  - [ ] 회원가입 화면에서도 동일하게 동작 확인    

## 테스트 미완료                                                                                                            
  - [ ] 인증 실패 케이스는 URL 직접 입력으로만 검증                                                                           
    (`/login?error=oauth_failed&social=kakao`)                                                                                
