### PR TITLE
Feat/#86: 인증 기반 라우트 보호 proxy 구현

### DIFF
--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -1,0 +1,2 @@
+export const PUBLIC_PATHS = ["/", "/login", "/signup"];
+export const AUTH_ONLY_PATHS = ["/login", "/signup"];

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,30 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { PUBLIC_PATHS } from "@/constants/paths";
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  const accessToken = request.cookies.get("accessToken")?.value;
+  const refreshToken = request.cookies.get("refreshToken")?.value;
+
+  const isAuthenticated = Boolean(accessToken || refreshToken);
+  console.log("isAuthenticated : ", isAuthenticated);
+
+  // 토큰 있는데 랜더링/로그인/회원가입
+  if (isAuthenticated && PUBLIC_PATHS.includes(pathname)) {
+    return NextResponse.redirect(new URL("/taskmate", request.url));
+  }
+
+  // 토큰 없는데 보호된 경로
+  if (!isAuthenticated && !PUBLIC_PATHS.includes(pathname)) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>  Closes #86

## 📝 작업 내용

 - `proxy.ts` 구현                                                                                     
    - 토큰 없으면 보호된 경로 접근 시 `/login` redirect
    - 토큰 있으면 로그인/회원가입 접근 시 `/taskmate` redirect                                          
  - 라우트 상수 관리 (`src/constants/paths.ts`)                                
    - `PUBLIC_PATHS`: 누구나 접근 가능한 경로                                                           
    - `AUTH_ONLY_PATHS`: 토큰 있으면 접근 불가한 경로      
    
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

## 테스트                                                                                             
  - [ ] 로그인 없이 `/taskmate` 접근 → `/login` redirect 확인                                           
  - [ ] 로그인 후 `/login` 접근 → `/taskmate` redirect 확인         