### PR TITLE
Feat/#95 fix: 빌드 시 useSearchParams Suspense 에러 수정  

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,19 +1,17 @@
-import React, { Suspense } from "react";
+import React from "react";
 
 import LoginForm from "@/components/auth/Login/LoginForm";
 import SnsLoginButtons from "@/components/auth/SnsLoginButtons";
 
 const LoginPage = () => {
   return (
-    // useSearchParams() 사용으로 인한 CSR Suspense 추가
-    // TODO: 공통 스켈레톤 UI 컴포넌트 구현 후 fallback으로 교체
-    <Suspense fallback={null}>
+    <>
       <LoginForm />
       <SnsLoginButtons
         label="SNS 계정으로 로그인"
         type="login"
       />
-    </Suspense>
+    </>
   );
 };
 

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,18 +1,14 @@
-import { Suspense } from "react";
-
 import SignupForm from "@/components/auth/Signup/SignupForm";
 import SnsLoginButtons from "@/components/auth/SnsLoginButtons";
 
 export default function SignupPage() {
   return (
-    // useSearchParams() 사용으로 인한 CSR Suspense 추가
-    // TODO: 공통 스켈레톤 UI 컴포넌트 구현 후 fallback으로 교체
-    <Suspense fallback={null}>
+    <>
       <SignupForm />
       <SnsLoginButtons
         label="SNS 계정으로 회원가입"
         type="signup"
       />
-    </Suspense>
+    </>
   );
 }

--- a/src/app/taskmate/layout.tsx
+++ b/src/app/taskmate/layout.tsx
@@ -1,7 +1,3 @@
-export const dynamic = "force-dynamic";
-
-import UserInitializer from "@/components/auth/UserInitializer";
-import AsyncBoundary from "@/components/common/AsyncBoundary";
 import { NavigationBar } from "@/components/NavigationBar";
 import NavigationBarProvider from "@/components/NavigationBar/provider";
 
@@ -12,12 +8,6 @@ export default function TaskmateLayout({
 }) {
   return (
     <div className="flex">
-      <AsyncBoundary
-        loadingFallback={null}
-        errorFallback={null}
-      >
-        <UserInitializer />
-      </AsyncBoundary>
       <NavigationBarProvider>
         <NavigationBar />
       </NavigationBarProvider>

--- a/src/app/taskmate/layout.tsx
+++ b/src/app/taskmate/layout.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import UserInitializer from "@/components/auth/UserInitializer";
 import AsyncBoundary from "@/components/common/AsyncBoundary";
 import { NavigationBar } from "@/components/NavigationBar";

--- a/src/components/auth/Login/LoginForm.tsx
+++ b/src/components/auth/Login/LoginForm.tsx
@@ -9,15 +9,15 @@ import { useOAuthError } from "@/features/auth/hooks/useOAuthError";
 import { loginAction } from "@/features/auth/login/actions/loginAction";
 import useLoginForm from "@/features/auth/login/hooks/useLoginForm";
 
+// useSearchParams() 사용으로 인한 CSR Suspense 추가
+const OAuthErrorHandler = () => {
+  useOAuthError("login");
+  return null;
+};
+
 const LoginForm = () => {
   const { values, showPassword, togglePassword, handleChange } = useLoginForm();
   const [state, formAction] = useActionState(loginAction, null);
-
-  // useSearchParams() 사용으로 인한 CSR Suspense 추가
-  const OAuthErrorHandler = () => {
-    useOAuthError("signup");
-    return null;
-  };
 
   return (
     <>

--- a/src/components/auth/Login/LoginForm.tsx
+++ b/src/components/auth/Login/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import React, { useActionState } from "react";
+import React, { Suspense, useActionState } from "react";
 
 import Button from "@/components/common/Button/Button";
 import { Icon } from "@/components/common/Icon";
@@ -12,9 +12,18 @@ import useLoginForm from "@/features/auth/login/hooks/useLoginForm";
 const LoginForm = () => {
   const { values, showPassword, togglePassword, handleChange } = useLoginForm();
   const [state, formAction] = useActionState(loginAction, null);
-  useOAuthError("login");
+
+  // useSearchParams() 사용으로 인한 CSR Suspense 추가
+  const OAuthErrorHandler = () => {
+    useOAuthError("signup");
+    return null;
+  };
+
   return (
     <>
+      <Suspense fallback={null}>
+        <OAuthErrorHandler />
+      </Suspense>
       <form
         className="tablet:gap-4 flex flex-col gap-2.5"
         action={formAction}

--- a/src/components/auth/Signup/SignupForm.tsx
+++ b/src/components/auth/Signup/SignupForm.tsx
@@ -8,6 +8,12 @@ import Input from "@/components/common/Input";
 import { useOAuthError } from "@/features/auth/hooks/useOAuthError";
 import useSignupForm from "@/features/auth/signup/hooks/useSignupForm";
 
+// useSearchParams() 사용으로 인한 CSR Suspense 추가
+const OAuthErrorHandler = () => {
+  useOAuthError("signup");
+  return null;
+};
+
 // TODO : 이메일 중복 체크 디자인 수정 예정
 const SignupForm = () => {
   const {
@@ -23,12 +29,6 @@ const SignupForm = () => {
     handleEmailDuplicate,
     isEmailChecked,
   } = useSignupForm();
-
-  // useSearchParams() 사용으로 인한 CSR Suspense 추가
-  const OAuthErrorHandler = () => {
-    useOAuthError("signup");
-    return null;
-  };
 
   return (
     <>

--- a/src/components/auth/Signup/SignupForm.tsx
+++ b/src/components/auth/Signup/SignupForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import React from "react";
+import React, { Suspense } from "react";
 
 import Button from "@/components/common/Button/Button";
 import { Icon } from "@/components/common/Icon";
@@ -23,9 +23,18 @@ const SignupForm = () => {
     handleEmailDuplicate,
     isEmailChecked,
   } = useSignupForm();
-  useOAuthError("signup");
+
+  // useSearchParams() 사용으로 인한 CSR Suspense 추가
+  const OAuthErrorHandler = () => {
+    useOAuthError("signup");
+    return null;
+  };
+
   return (
     <>
+      <Suspense fallback={null}>
+        <OAuthErrorHandler />
+      </Suspense>
       <form
         className="tablet:gap-4 flex w-full flex-col gap-3.5"
         onSubmit={handleSubmit}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closes #135 

## 📝 작업 내용

 `useOAuthError` 훅이 `useSearchParams()`를 호출하는데,                                                                                                          
  컴포넌트 내부에 Suspense가 없어 빌드 시 정적 생성 단계에서 에러 발생

변경 내용                                                                 
  - `LoginForm`, `SignupForm`에서 `useOAuthError`를 별도 `OAuthErrorHandler` 컴포넌트로 분리                                                                      
  - 해당 컴포넌트를 `<Suspense>`로 직접 감싸 빌드 에러 해결                                 
  - `login/page.tsx`, `signup/page.tsx`의 불필요한 Suspense 제거  

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
