### PR TITLE
 chore: 미들웨어 매처에 mockServiceWorker 제외 추가

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,7 +10,6 @@ export function proxy(request: NextRequest) {
   const refreshToken = request.cookies.get("refreshToken")?.value;
 
   const isAuthenticated = Boolean(accessToken || refreshToken);
-  console.log("isAuthenticated : ", isAuthenticated);
 
   // 토큰 있는데 랜더링/로그인/회원가입
   if (isAuthenticated && PUBLIC_PATHS.includes(pathname)) {
@@ -26,5 +25,7 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico|mockServiceWorker).*)",
+  ],
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closes #140 

## 📝 작업 내용

- MSW 서비스워커 파일이 미들웨어에 가로채지면서 토큰이 하나만 있을 때 redirect가 정상 동작하지 않는 문제 수정 
- 미들웨어 matcher에 `mockServiceWorker` 제외 패턴 추가        

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
