### PR TITLE
Feat/#143: 루트 경로(/) 접근 시 /login으로 리다이렉트

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,10 @@ export function proxy(request: NextRequest) {
   const refreshToken = request.cookies.get("refreshToken")?.value;
 
   const isAuthenticated = Boolean(accessToken || refreshToken);
+  // 루트 경로는 항상 login으로
+  if (pathname === "/") {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
 
   // 토큰 있는데 랜더링/로그인/회원가입
   if (isAuthenticated && PUBLIC_PATHS.includes(pathname)) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closes #143 루트 경로(/) 접근 시 /login으로 리다이렉트

## 📝 작업 내용

- `proxy.ts` 미들웨어에 `/` 경로 접근 시 `/login` redirect 추가                           
- 토큰 있는 경우 `/login` → `/taskmate`로 자동 이동 (기존 로직 활용)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
