### PR TITLE
Refactor/#115 refactor: 쿠키 설정 유틸 함수 분리

### DIFF
--- a/src/lib/auth/cookies.ts
+++ b/src/lib/auth/cookies.ts
@@ -1,3 +1,4 @@
+import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
 const ACCESS_TOKEN_COOKIE = {
@@ -16,6 +17,8 @@ const REFRESH_TOKEN_COOKIE = {
   maxAge: 60 * 60 * 24 * 14,
 };
 
+// NextResponse 방식 (route handler용)
+// google/kakao callback, [...path] route에서 사용
 export function setTokenCookies(
   response: NextResponse,
   accessToken: string,
@@ -25,4 +28,20 @@ export function setTokenCookies(
   if (refreshToken) {
     response.cookies.set("refreshToken", refreshToken, REFRESH_TOKEN_COOKIE);
   }
+}
+
+// cookieStore 방식 (server action용)
+// loginAction.ts에서 사용
+export async function setTokenCookiesServerAction(
+  accessToken: string,
+  refreshToken: string,
+) {
+  const cookieStore = await cookies();
+  cookieStore.set("accessToken", accessToken, ACCESS_TOKEN_COOKIE);
+  cookieStore.set("refreshToken", refreshToken, REFRESH_TOKEN_COOKIE);
+}
+
+export function deleteTokenCookies(response: NextResponse) {
+  response.cookies.delete("accessToken");
+  response.cookies.delete("refreshToken");
 }

--- a/src/lib/auth/cookies.ts
+++ b/src/lib/auth/cookies.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+const ACCESS_TOKEN_COOKIE = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+  maxAge: 60 * 59,
+};
+
+const REFRESH_TOKEN_COOKIE = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+  maxAge: 60 * 60 * 24 * 14,
+};
+
+export function setTokenCookies(
+  response: NextResponse,
+  accessToken: string,
+  refreshToken?: string,
+) {
+  response.cookies.set("accessToken", accessToken, ACCESS_TOKEN_COOKIE);
+  if (refreshToken) {
+    response.cookies.set("refreshToken", refreshToken, REFRESH_TOKEN_COOKIE);
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Cloese #115 

## 📝 작업 내용

여러 곳에 중복된 쿠키 세팅 로직을 유틸 함수로 분리
 - `src/lib/auth/cookies.ts` 추가                                                                                                    
    - `setTokenCookies` — route handler용 (NextResponse)                                                                              
    - `setTokenCookiesServerAction` — server action용 (cookies())
    - `deleteTokenCookies` — 쿠키 삭제  

## 추후 작업                                                                                                                        
  - 기존 4곳 쿠키 세팅 코드를 유틸 함수로 교체 예정                                                                                   
    - `src/app/api/auth/callback/google/route.ts`                                                                                     
    - `src/app/api/auth/callback/kakao/route.ts`                                                                                      
    - `src/app/api/[...path]/route.ts`                                                                                                
    - `src/features/auth/login/actions/loginAction.ts`     
   
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

