### PR TITLE
refactor: BFF 프록시 에러 처리 및 토큰 재발급 로직 개선

### DIFF
--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -1,84 +1,126 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 
+import { deleteTokenCookies, setTokenCookies } from "@/lib/auth/cookies";
+
+async function refreshAndRetry({
+  refreshToken,
+  url,
+  request,
+  headers,
+  body,
+}: {
+  refreshToken: string | undefined;
+  url: string;
+  request: NextRequest;
+  headers: HeadersInit;
+  body: string | undefined;
+}) {
+  const refreshRes = await fetch(
+    `${process.env.BACKEND_URL}/api/auth/refresh`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    },
+  );
+
+  if (!refreshRes.ok) {
+    const response = NextResponse.json(
+      { message: "세션이 만료되었습니다. 다시 로그인해주세요." },
+      { status: 401 },
+    );
+    deleteTokenCookies(response);
+    return response;
+  }
+
+  const {
+    data: { accessToken: newAccessToken, refreshToken: newRefreshToken },
+  } = await refreshRes.json();
+
+  if (!newAccessToken) {
+    const response = NextResponse.json(
+      { message: "세션이 만료되었습니다. 다시 로그인해주세요." },
+      { status: 401 },
+    );
+    deleteTokenCookies(response);
+    return response;
+  }
+
+  const retryRes = await fetch(url, {
+    method: request.method,
+    headers: {
+      ...headers,
+      Authorization: `Bearer ${newAccessToken}`,
+    },
+    body,
+  });
+
+  if (retryRes.status === 204) return new NextResponse(null, { status: 204 });
+
+  const data = await retryRes.json();
+  const res = NextResponse.json(data, { status: retryRes.status });
+
+  setTokenCookies(res, newAccessToken, newRefreshToken);
+
+  return res;
+}
+
 async function handler(
   request: NextRequest,
   { params }: { params: Promise<{ path: string[] }> },
 ) {
-  const { path } = await params;
-  const pathname = path.join("/");
-  const { searchParams } = new URL(request.url);
-  const queryString = searchParams.toString();
-  const url = queryString
-    ? `${process.env.BACKEND_URL}/${pathname}?${queryString}`
-    : `${process.env.BACKEND_URL}/${pathname}`;
+  try {
+    const { path } = await params;
+    const pathname = path.join("/");
+    const { searchParams } = new URL(request.url);
+    const queryString = searchParams.toString();
 
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get("accessToken")?.value;
-
-  const contentType = request.headers.get("Content-Type");
-
-  const headers: HeadersInit = {
-    ...(contentType && { "Content-Type": contentType }),
-    ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
-  };
-
-  const hasBody = !["GET", "HEAD"].includes(request.method);
-  const body = hasBody ? await request.text() : undefined;
-
-  const backendRes = await fetch(url, {
-    method: request.method,
-    headers,
-    body,
-  });
-
-  if (backendRes.status === 401) {
-    const refreshToken = cookieStore.get("refreshToken")?.value;
-
-    const refreshRes = await fetch(
-      `${process.env.BACKEND_URL}/api/auth/refresh`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ refreshToken }),
-      },
-    );
-
-    if (!refreshRes.ok) {
-      const response = NextResponse.json(
-        { message: "세션이 만료되었습니다. 다시 로그인해주세요." },
-        { status: 401 },
-      );
-      response.cookies.delete("accessToken");
-      response.cookies.delete("refreshToken");
-      return response;
+    if (!process.env.BACKEND_URL) {
+      return NextResponse.json({ message: "서버 설정 오류" }, { status: 500 });
     }
 
-    const { accessToken: newAccessToken } = await refreshRes.json();
+    const url = queryString
+      ? `${process.env.BACKEND_URL}/${pathname}?${queryString}`
+      : `${process.env.BACKEND_URL}/${pathname}`;
 
-    const retryRes = await fetch(url, {
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get("accessToken")?.value;
+    const refreshToken = cookieStore.get("refreshToken")?.value;
+
+    const contentType = request.headers.get("Content-Type");
+
+    const headers: HeadersInit = {
+      ...(contentType && { "Content-Type": contentType }),
+      ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+    };
+
+    const hasBody = !["GET", "HEAD"].includes(request.method);
+    const body = hasBody ? await request.text() : undefined;
+
+    const backendRes = await fetch(url, {
       method: request.method,
-      headers: {
-        ...headers,
-        Authorization: `Bearer ${newAccessToken}`,
-      },
+      headers,
       body,
     });
 
-    const data = await retryRes.json();
-    const res = NextResponse.json(data, { status: retryRes.status });
+    if (
+      (backendRes.status === 401 || backendRes.status === 403) &&
+      refreshToken
+    ) {
+      return refreshAndRetry({ refreshToken, url, request, headers, body });
+    }
 
-    res.cookies.set("accessToken", newAccessToken, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
-      sameSite: "lax",
-    });
-
-    return res;
+    if (backendRes.status === 204)
+      return new NextResponse(null, { status: 204 });
+    const data = await backendRes.json();
+    return NextResponse.json(data, { status: backendRes.status });
+  } catch {
+    return NextResponse.json(
+      { message: "서버와 통신할 수 없습니다." },
+      { status: 503 },
+    );
   }
-
-  const data = await backendRes.json();
-  return NextResponse.json(data, { status: backendRes.status });
 }
 
 export const GET = handler;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closes #116 

## 📝 작업 내용

  - `refreshAndRetry` 함수 분리 (401/403 중복 로직 통합)                                                                                                          
  - 쿠키 유틸 함수 적용 (`setTokenCookies`, `deleteTokenCookies`)                                                                                                 
  - 토큰 재발급 시 `newRefreshToken`도 함께 갱신                 
  - `newAccessToken` undefined 체크 추가                                                                                                                          
  - 204 No Content 처리 추가                                                                                                                                    
  - `BACKEND_URL` 환경변수 누락 체크 추가                                                                                                                         
  - 네트워크 에러 try-catch 처리 (503 반환)                                                                                                                       
  - refresh API 응답 구조 수정 (`data.data.accessToken`)      

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
