### PR TITLE
Feat/#165 : 로그아웃 기능 구현

### DIFF
--- a/src/components/NavigationBar/index.tsx
+++ b/src/components/NavigationBar/index.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/utils/utils";
 
 import UserProfile from "../auth/UserProfile";
 import AsyncBoundary from "../common/AsyncBoundary";
+import LogoutButton from "../common/LogoutButton";
 import { Header } from "./Header";
 import { Item } from "./parts/Item";
 import { List } from "./parts/List";
@@ -68,10 +69,11 @@ export const NavigationBar = () => {
           </div>
 
           {/* @TODO: 저장된 유저 정보 전달 필요 ( 재인님 TODO ) */}
-          <div className="mt-4 border-t border-gray-100 bg-white pt-4">
+          <div className="mt-4 flex items-center justify-center gap-1 border-t border-gray-100 bg-white pt-4">
             <AsyncBoundary errorFallback={<div>에러</div>}>
               <UserProfile />
             </AsyncBoundary>
+            <LogoutButton />
           </div>
         </>
       )}

--- a/src/components/auth/LogoutModal/LogoutModal.tsx
+++ b/src/components/auth/LogoutModal/LogoutModal.tsx
@@ -1,0 +1,34 @@
+"use client";
+import Button from "@/components/common/Button/Button";
+import { Modal } from "@/components/common/Modal";
+import { useLogout } from "@/hooks/useLogout";
+
+export const LogoutModal = ({ onClose }: { onClose: () => void }) => {
+  const { logout } = useLogout();
+  return (
+    <Modal.Root onClose={onClose}>
+      <Modal.Backdrop />
+      <Modal.Content>
+        <Modal.Title>로그아웃 하시겠어요?</Modal.Title>
+        <Modal.Actions>
+          <Button
+            variant="secondary"
+            size="md"
+            className="flex-1"
+            onClick={onClose}
+          >
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            size="md"
+            className="flex-1"
+            onClick={logout}
+          >
+            로그아웃
+          </Button>
+        </Modal.Actions>
+      </Modal.Content>
+    </Modal.Root>
+  );
+};

--- a/src/components/auth/LogoutModal/index.tsx
+++ b/src/components/auth/LogoutModal/index.tsx
@@ -1,0 +1,1 @@
+export { LogoutModal } from "./LogoutModal";

--- a/src/components/common/LogoutButton/LogoutButton.tsx
+++ b/src/components/common/LogoutButton/LogoutButton.tsx
@@ -1,0 +1,31 @@
+"use client";
+import React from "react";
+
+import { LogoutModal } from "@/components/auth/LogoutModal";
+import { Icon } from "@/components/common/Icon/index";
+import { useOverlay } from "@/hooks/useOverlay";
+
+const LogoutButton = () => {
+  const overlay = useOverlay();
+
+  const handleClick = () => {
+    overlay.open(
+      "logout-modal",
+      <LogoutModal onClose={() => overlay.close()} />,
+    );
+  };
+  return (
+    <button
+      className="bg-inverse-normal flex size-16 shrink-0 items-center justify-center rounded-[99px] ring-1 ring-gray-300 ring-inset"
+      onClick={handleClick}
+    >
+      <Icon
+        name="Out"
+        size={24}
+        className="p-1 text-gray-500"
+      />
+    </button>
+  );
+};
+
+export default LogoutButton;

--- a/src/components/common/LogoutButton/index.ts
+++ b/src/components/common/LogoutButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LogoutButton";

--- a/src/features/auth/logout/actions/logoutAction.ts
+++ b/src/features/auth/logout/actions/logoutAction.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+export async function logoutAction() {
+  const cookieStore = await cookies();
+  cookieStore.delete("accessToken");
+  cookieStore.delete("refreshToken");
+}

--- a/src/hooks/useLogout/index.ts
+++ b/src/hooks/useLogout/index.ts
@@ -1,0 +1,1 @@
+export { useLogout } from "./useLogout";

--- a/src/hooks/useLogout/useLogout.ts
+++ b/src/hooks/useLogout/useLogout.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+import { logoutAction } from "@/features/auth/logout/actions/logoutAction";
+
+import { useToast } from "../useToast";
+
+export function useLogout() {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const logout = async () => {
+    try {
+      queryClient.clear();
+      await logoutAction();
+      router.push("/login");
+    } catch {
+      toast({ title: "로그아웃에 실패했어요.", variant: "error" });
+    }
+  };
+
+  return { logout };
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- Closes #165 

## 📝 작업 내용

- 로그아웃 확인 모달 구현 (`LogoutModal`)                                                                                                
- 로그아웃 로직 훅으로 분리 (`useLogout`) — 쿠키 삭제, React Query 캐시 초기화, /login 리다이렉트                                        
- 로그아웃 Server Action 구현 (`logoutAction`) — accessToken, refreshToken 쿠키 삭제             
- 네비게이션 바에 로그아웃 버튼 추가              

### 스크린샷 (선택)
<img width="619" height="587" alt="스크린샷 2026-04-02 오후 9 51 34" src="https://github.com/user-attachments/assets/35a2b324-b3e8-4f21-b852-d7b0658ba1b6" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
