### PR TITLE
Feat/#179 공통 ConfirmModal 컴포넌트 구현

### DIFF
--- a/src/components/common/ConfirmModal/ConfirmModal.stories.tsx
+++ b/src/components/common/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import ConfirmModal from "./ConfirmModal";
+
+const meta: Meta<typeof ConfirmModal> = {
+  title: "Components/ConfirmModal",
+  component: ConfirmModal,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmModal>;
+
+export const Default: Story = {
+  args: {
+    title: "타이틀",
+    confirmLabel: "확인",
+    cancelLabel: "취소",
+    description: "상세설명",
+    info: "인포",
+    onConfirm: () => {},
+    onClose: () => {},
+  },
+};
+
+export const Logout: Story = {
+  args: {
+    title: "로그아웃 하시겠어요?",
+    confirmLabel: "로그아웃",
+    cancelLabel: "취소",
+    onConfirm: () => {},
+    onClose: () => {},
+  },
+};

--- a/src/components/common/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal/ConfirmModal.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Button from "@/components/common/Button/Button";
 import { Icon } from "@/components/common/Icon";
 import { Modal } from "@/components/common/Modal";
+import TextButton from "@/components/common/TextButton/TextButton";
 
 interface ConfirmModalProps {
   title: string;
@@ -54,13 +55,13 @@ const ConfirmModal = ({
           >
             {confirmLabel}
           </Button>
-          <Button
-            variant="secondary"
+          <TextButton
+            variant="primary"
             onClick={onClose}
             className="w-full"
           >
             {cancelLabel}
-          </Button>
+          </TextButton>
         </Modal.Actions>
       </Modal.Content>
     </Modal.Root>

--- a/src/components/common/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+import Button from "@/components/common/Button/Button";
+import { Icon } from "@/components/common/Icon";
+import { Modal } from "@/components/common/Modal";
+
+interface ConfirmModalProps {
+  title: string;
+  description?: string;
+  info?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+const ConfirmModal = ({
+  title,
+  description,
+  info,
+  confirmLabel = "확인",
+  cancelLabel = "취소",
+  onConfirm,
+  onClose,
+}: ConfirmModalProps) => {
+  return (
+    <Modal.Root onClose={onClose}>
+      <Modal.Backdrop />
+      <Modal.Content>
+        <Modal.Title>{title}</Modal.Title>
+        {(description || info) && (
+          <div className="mt-1.5 flex flex-col gap-3">
+            {description && (
+              <p className="text-label-1 tablet:text-body-1 text-center font-medium text-gray-400">
+                {description}
+              </p>
+            )}
+            {info && (
+              <p className="text-label-2 tablet:gap-2.5 tablet:text-body-2 flex items-center justify-center gap-1.5 font-medium text-blue-700">
+                <Icon
+                  name="Info"
+                  className="tablet:w-6 tablet:h-6 h-5 w-5"
+                />
+                {info}
+              </p>
+            )}
+          </div>
+        )}
+        <Modal.Actions className="tablet:mt-10 mt-4 flex flex-col">
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            className="w-full"
+          >
+            {confirmLabel}
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            className="w-full"
+          >
+            {cancelLabel}
+          </Button>
+        </Modal.Actions>
+      </Modal.Content>
+    </Modal.Root>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/common/ConfirmModal/index.tsx
+++ b/src/components/common/ConfirmModal/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./ConfirmModal";

--- a/src/components/common/Icon/iconMap.ts
+++ b/src/components/common/Icon/iconMap.ts
@@ -28,6 +28,7 @@ import PipeGreen from "./svg/feature/Pipe_Green.svg";
 import FilledXCircle from "./svg/FilledXCircle.svg";
 import Flag from "./svg/Flag.svg";
 import Home from "./svg/Home/Home.svg";
+import Info from "./svg/Info.svg";
 import Kebab from "./svg/Kebab.svg";
 import LogoIcon from "./svg/Logo/Icon.svg";
 import LogoText from "./svg/Logo/Text.svg";
@@ -86,6 +87,7 @@ export const iconMap = {
   Dot,
   GreenCharacter,
   BlueCharacter,
+  Info,
 } as const;
 
 export type IconName = keyof typeof iconMap;

--- a/src/components/common/Icon/svg/Info.svg
+++ b/src/components/common/Icon/svg/Info.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12ZM13 8C13 8.55228 12.5523 9 12 9C11.4477 9 11 8.55228 11 8C11 7.44772 11.4477 7 12 7C12.5523 7 13 7.44772 13 8ZM13 17V11H11V17H13Z"  fill="currentColor"/>
+</svg>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

>  Closes #179 

## 📝 작업 내용

-  Info 아이콘 SVG 추가 및 iconMap 등록 (스크린샷에는 없지만 구현되어있습니다)
-  ConfirmModal 공통 컴포넌트 구현 
-  Storybook 스토리 추가 (Default, Logout 케이스)  


### 스크린샷 (선택)
<img width="601" height="386" alt="스크린샷 2026-04-06 오후 5 49 48" src="https://github.com/user-attachments/assets/c174594d-653e-49f1-b565-3c229dc9cdf1" />

## 💬 리뷰 요구사항(선택)

디자인(스타일링)은 추후 변경될 수 있으나, 컴포넌트 인터페이스 및 기능은 안정적으로 사용 가능합니다.     