### PR TITLE
Feat/#201 팀 생성 페이지 사용자 경험 향상

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ next-env.d.ts
 
 *storybook.log
 storybook-static
+
+CLAUDE.md

--- a/src/app/taskmate/layout.tsx
+++ b/src/app/taskmate/layout.tsx
@@ -11,7 +11,7 @@ export default function TaskmateLayout({
       <div className="flex">
         <NavigationBar />
 
-        <div className="mx-auto w-full px-[40px] py-[80px]">{children}</div>
+        <div className="mx-auto w-full">{children}</div>
       </div>
     </NavigationBarProvider>
   );

--- a/src/app/taskmate/team/create/page.tsx
+++ b/src/app/taskmate/team/create/page.tsx
@@ -11,7 +11,7 @@ export default function Page() {
 
         <Spacing size={32} />
 
-        <div className="mobile:w-[335px] tablet:w-[560px] mobile:p-4 flex flex-col rounded-4xl bg-white p-8 pt-10">
+        <div className="mobile:w-[335px] tablet:w-[560px] mobile:p-8 mobile:pt-10 flex max-w-full flex-col rounded-4xl bg-white p-4">
           <CreateForm.Form />
           <Spacing size={16} />
           <CreateForm.Cancel />

--- a/src/app/taskmate/team/create/page.tsx
+++ b/src/app/taskmate/team/create/page.tsx
@@ -3,7 +3,7 @@ import { CreateForm } from "@/components/team/createForm";
 
 export default function Page() {
   return (
-    <div className="flex h-screen w-full items-center justify-center">
+    <div className="mobile:px-10 flex h-screen w-full items-center justify-center px-5">
       <div className="flex flex-col items-start justify-center">
         <h1 className="typography-title-3 pl-2 font-semibold">
           새로운 팀을 생성해주세요

--- a/src/app/taskmate/team/create/page.tsx
+++ b/src/app/taskmate/team/create/page.tsx
@@ -13,6 +13,7 @@ export default function Page() {
 
         <div className="mobile:w-[335px] tablet:w-[560px] mobile:p-8 mobile:pt-10 flex max-w-full flex-col rounded-4xl bg-white p-4">
           <CreateForm.Form />
+
           <Spacing size={16} />
           <CreateForm.Cancel />
         </div>

--- a/src/components/team/createForm/Cancel.tsx
+++ b/src/components/team/createForm/Cancel.tsx
@@ -13,7 +13,7 @@ export default function Cancel() {
       className="self-center"
       onClick={() => router.back()}
     >
-      <span className="typography-body-2 text-gray-400">취소하기</span>
+      취소하기
     </TextButton>
   );
 }

--- a/src/components/team/createForm/Form.test.tsx
+++ b/src/components/team/createForm/Form.test.tsx
@@ -6,6 +6,7 @@ import { teamApi } from "@/features/team/api";
 import Form from "./Form";
 
 const backMock = jest.fn();
+const toastMock = jest.fn();
 
 jest.mock("@/features/team/api", () => ({
   teamApi: {
@@ -16,6 +17,12 @@ jest.mock("@/features/team/api", () => ({
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
     back: backMock,
+  }),
+}));
+
+jest.mock("@/hooks/useToast", () => ({
+  useToast: () => ({
+    toast: toastMock,
   }),
 }));
 
@@ -34,6 +41,7 @@ const renderWithQueryClient = (ui: React.ReactElement) => {
 describe("TeamCreateForm", () => {
   beforeEach(() => {
     backMock.mockClear();
+    toastMock.mockClear();
     jest.clearAllMocks();
   });
 
@@ -52,10 +60,13 @@ describe("TeamCreateForm", () => {
       expect(backMock).toHaveBeenCalledTimes(1);
     });
 
-    expect(teamApi.create).toHaveBeenCalledWith("새로운 팀");
+    expect(teamApi.create).toHaveBeenCalledWith(
+      "새로운 팀",
+      expect.any(Object),
+    );
   });
 
-  test("팀 생성 요청 실패 시 에러 메시지를 보여준다", async () => {
+  test("팀 생성 요청 실패 시 토스트 에러를 보여준다", async () => {
     (teamApi.create as jest.Mock).mockRejectedValue({
       message: "이미 존재하는 팀 이름입니다.",
     });
@@ -68,11 +79,17 @@ describe("TeamCreateForm", () => {
     const submitButton = screen.getByRole("button", { name: "생성하기" });
     fireEvent.click(submitButton);
 
-    expect(
-      await screen.findByText("이미 존재하는 팀 이름입니다."),
-    ).toBeInTheDocument();
-
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1);
+    });
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: "error",
+        title: "팀 생성 실패",
+        description: "이미 존재하는 팀 이름입니다.",
+      }),
+    );
     expect(backMock).not.toHaveBeenCalled();
-    expect(teamApi.create).toHaveBeenCalledWith("중복팀");
+    expect(teamApi.create).toHaveBeenCalledWith("중복팀", expect.any(Object));
   });
 });

--- a/src/components/team/createForm/Form.test.tsx
+++ b/src/components/team/createForm/Form.test.tsx
@@ -53,7 +53,9 @@ describe("TeamCreateForm", () => {
     fireEvent.change(input, { target: { value: "새로운 팀" } });
 
     const submitButton = screen.getByRole("button", { name: "생성하기" });
-    fireEvent.click(submitButton);
+    const form = submitButton.closest("form");
+    if (!form) throw new Error("form not found");
+    fireEvent.submit(form);
 
     // Assert
     expect(handleSubmit).toHaveBeenCalledTimes(1);

--- a/src/components/team/createForm/Form.test.tsx
+++ b/src/components/team/createForm/Form.test.tsx
@@ -1,95 +1,61 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
-import { teamApi } from "@/features/team/api";
+import { ToastProvider } from "@/components/common/Toast";
+import { useCreateTeamForm } from "@/features/team/hooks/useCreateTeamForm";
 
 import Form from "./Form";
 
-const backMock = jest.fn();
-const toastMock = jest.fn();
-
-jest.mock("@/features/team/api", () => ({
-  teamApi: {
-    create: jest.fn(),
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
   },
-}));
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <ToastProvider>{children}</ToastProvider>
+  </QueryClientProvider>
+);
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
-    back: backMock,
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
   }),
 }));
 
-jest.mock("@/hooks/useToast", () => ({
-  useToast: () => ({
-    toast: toastMock,
+const handleSubmitMock = jest.fn();
+jest.mock("@/features/team/hooks/useCreateTeamForm", () => ({
+  useCreateTeamForm: () => ({
+    handleSubmit: handleSubmitMock,
+    nameError: "",
   }),
 }));
-
-const renderWithQueryClient = (ui: React.ReactElement) => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-    },
-  });
-
-  return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
-  );
-};
 
 describe("TeamCreateForm", () => {
   beforeEach(() => {
-    backMock.mockClear();
-    toastMock.mockClear();
+    queryClient.clear();
     jest.clearAllMocks();
   });
 
-  test("팀 생성 요청은 제대로 전달되는지 확인", async () => {
-    (teamApi.create as jest.Mock).mockResolvedValue({ success: true });
+  test("팀 생성 요청이 제대로 호출 되는지 확인", async () => {
+    // Arrange
+    const { handleSubmit } = useCreateTeamForm();
 
-    renderWithQueryClient(<Form />);
+    render(<Form />, { wrapper });
 
+    // Act
     const input = screen.getByPlaceholderText("팀 이름을 입력해주세요");
     fireEvent.change(input, { target: { value: "새로운 팀" } });
 
     const submitButton = screen.getByRole("button", { name: "생성하기" });
     fireEvent.click(submitButton);
 
-    await waitFor(() => {
-      expect(backMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(teamApi.create).toHaveBeenCalledWith(
-      "새로운 팀",
-      expect.any(Object),
-    );
-  });
-
-  test("팀 생성 요청 실패 시 토스트 에러를 보여준다", async () => {
-    (teamApi.create as jest.Mock).mockRejectedValue({
-      message: "이미 존재하는 팀 이름입니다.",
-    });
-
-    renderWithQueryClient(<Form />);
-
-    const input = screen.getByPlaceholderText("팀 이름을 입력해주세요");
-    fireEvent.change(input, { target: { value: "중복팀" } });
-
-    const submitButton = screen.getByRole("button", { name: "생성하기" });
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(toastMock).toHaveBeenCalledTimes(1);
-    });
-    expect(toastMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        variant: "error",
-        title: "팀 생성 실패",
-        description: "이미 존재하는 팀 이름입니다.",
-      }),
-    );
-    expect(backMock).not.toHaveBeenCalled();
-    expect(teamApi.create).toHaveBeenCalledWith("중복팀", expect.any(Object));
+    // Assert
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/team/createForm/Form.tsx
+++ b/src/components/team/createForm/Form.tsx
@@ -41,15 +41,16 @@ export default function Form() {
     >
       <label className="typography-heading-2 font-semibold">팀 이름</label>
 
-      <Input
-        name="name"
-        required
-        type="text"
-        maxLength={TEAM_NAME_MAX_LENGTH}
-        className="mobile:w-[303px] tablet:w-[496px]"
-        placeholder="팀 이름을 입력해주세요"
-        errorMessage={errorMessage ?? undefined}
-      />
+      <div className="w-full">
+        <Input
+          name="name"
+          required
+          type="text"
+          maxLength={TEAM_NAME_MAX_LENGTH}
+          placeholder="팀 이름을 입력해주세요"
+          errorMessage={errorMessage ?? undefined}
+        />
+      </div>
 
       <Button
         size="xl"

--- a/src/components/team/createForm/Form.tsx
+++ b/src/components/team/createForm/Form.tsx
@@ -1,38 +1,12 @@
 "use client";
 
-import { useQueryClient } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
-
 import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input";
 import { TEAM_NAME_MAX_LENGTH } from "@/constants/team";
-import { teamApi } from "@/features/team/api";
-import type { ApiError } from "@/lib/api/types";
+import { useTeamCreateForm } from "@/features/team/hooks/useTeamCreateForm";
 
 export default function Form() {
-  const router = useRouter();
-  const queryClient = useQueryClient();
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const nameInput = e.currentTarget.elements.namedItem("name");
-    const name = nameInput instanceof HTMLInputElement ? nameInput.value : "";
-
-    try {
-      const response = await teamApi.create(name);
-
-      if (response.success) {
-        await queryClient.invalidateQueries({ queryKey: ["teams", "all"] });
-        router.back();
-      }
-    } catch (error) {
-      const apiError = error as ApiError;
-
-      setErrorMessage(apiError.message);
-    }
-  };
+  const { handleSubmit, nameError } = useTeamCreateForm();
 
   return (
     <form
@@ -48,7 +22,7 @@ export default function Form() {
           type="text"
           maxLength={TEAM_NAME_MAX_LENGTH}
           placeholder="팀 이름을 입력해주세요"
-          errorMessage={errorMessage ?? undefined}
+          errorMessage={nameError}
         />
       </div>
 

--- a/src/components/team/createForm/Form.tsx
+++ b/src/components/team/createForm/Form.tsx
@@ -3,10 +3,10 @@
 import Button from "@/components/common/Button/Button";
 import Input from "@/components/common/Input";
 import { TEAM_NAME_MAX_LENGTH } from "@/constants/team";
-import { useTeamCreateForm } from "@/features/team/hooks/useTeamCreateForm";
+import { useCreateTeamForm } from "@/features/team/hooks/useCreateTeamForm";
 
 export default function Form() {
-  const { handleSubmit, nameError } = useTeamCreateForm();
+  const { handleSubmit, nameError } = useCreateTeamForm();
 
   return (
     <form

--- a/src/components/team/createForm/Form.tsx
+++ b/src/components/team/createForm/Form.tsx
@@ -29,7 +29,7 @@ export default function Form() {
       <Button
         size="xl"
         type="submit"
-        className="w-full"
+        className="w-full break-keep"
       >
         생성하기
       </Button>

--- a/src/features/team/hooks/mutation/useCreateTeamMutation.ts
+++ b/src/features/team/hooks/mutation/useCreateTeamMutation.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useMutation, UseMutationOptions } from "@tanstack/react-query";
+
+import { teamApi } from "@/features/team/api";
+import type { ApiError } from "@/lib/api/types";
+
+import { ResponseCreateTeam } from "../../types";
+
+type UseCreateTeamMutationParams = UseMutationOptions<
+  ResponseCreateTeam,
+  ApiError,
+  string,
+  unknown
+>;
+
+export const useCreateTeamMutation = (options: UseCreateTeamMutationParams) => {
+  return useMutation({
+    mutationFn: teamApi.create,
+    ...options,
+  });
+};

--- a/src/features/team/hooks/useCreateTeamForm.ts
+++ b/src/features/team/hooks/useCreateTeamForm.ts
@@ -10,7 +10,7 @@ import { createTeamSchema } from "@/features/team/types";
 import { useToast } from "@/hooks/useToast";
 import type { ApiError } from "@/lib/api/types";
 
-export const useTeamCreateForm = () => {
+export const useCreateTeamForm = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { toast } = useToast();

--- a/src/features/team/hooks/useTeamCreateForm.ts
+++ b/src/features/team/hooks/useTeamCreateForm.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { ComponentProps, useState } from "react";
+
+import { useCreateTeamMutation } from "@/features/team/hooks/mutation/useCreateTeamMutation";
+import { teamQueries } from "@/features/team/query/team.queryKey";
+import { createTeamSchema } from "@/features/team/types";
+import { useToast } from "@/hooks/useToast";
+import type { ApiError } from "@/lib/api/types";
+
+export const useTeamCreateForm = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const [nameError, setNameError] = useState("");
+
+  const createMutation = useCreateTeamMutation({
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: teamQueries.all().queryKey });
+      toast({
+        variant: "success",
+        title: "팀 생성 완료",
+        description: "팀이 생성되었습니다.",
+      });
+      router.back();
+    },
+    onError: (error: ApiError) => {
+      toast({
+        variant: "error",
+        title: "팀 생성 실패",
+        description: error.message ?? "잠시 후 다시 시도해주세요.",
+      });
+    },
+  });
+
+  const handleSubmit: ComponentProps<"form">["onSubmit"] = (e) => {
+    e.preventDefault();
+
+    const formData = new FormData(e.currentTarget);
+    const name = formData.get("name");
+    const parsed = createTeamSchema.safeParse({ name });
+
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors;
+      setNameError(fieldErrors.name?.[0] ?? "");
+      return;
+    }
+
+    setNameError("");
+    createMutation.mutate(parsed.data.name);
+  };
+
+  return {
+    handleSubmit,
+    nameError,
+  };
+};

--- a/src/features/team/types.ts
+++ b/src/features/team/types.ts
@@ -1,6 +1,7 @@
 import z from "zod";
 
 import { TEAM_NAME_MAX_LENGTH } from "@/constants/team";
+import { ApiResponse } from "@/lib/api/types";
 
 export const createTeamSchema = z.object({
   name: z
@@ -13,16 +14,7 @@ export const createTeamSchema = z.object({
     ),
 });
 
-export interface ResponseCreateTeam {
-  success: true;
-}
-
-export interface ResponseCreateTeamError {
-  success: false;
-  error: {
-    message: string;
-  };
-}
+export type ResponseCreateTeam = ApiResponse<void>;
 
 export interface TeamSummary {
   teamId: number;

--- a/src/features/team/types.ts
+++ b/src/features/team/types.ts
@@ -1,3 +1,18 @@
+import z from "zod";
+
+import { TEAM_NAME_MAX_LENGTH } from "@/constants/team";
+
+export const createTeamSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "팀 이름을 입력해주세요.")
+    .max(
+      TEAM_NAME_MAX_LENGTH,
+      `팀 이름은 ${TEAM_NAME_MAX_LENGTH}자 이내로 입력해주세요.`,
+    ),
+});
+
 export interface ResponseCreateTeam {
   success: true;
 }

--- a/src/hooks/useBreakpoint/index.ts
+++ b/src/hooks/useBreakpoint/index.ts
@@ -3,13 +3,14 @@ import { useEffect, useState } from "react";
 type Breakpoint = "mobile" | "tablet" | "desktop";
 
 const BREAKPOINTS = {
+  mobile: 375,
   tablet: 744,
   desktop: 1280,
 } as const;
 
 function getBreakpoint(width: number): Breakpoint {
-  if (width >= BREAKPOINTS.desktop) return "desktop";
-  if (width >= BREAKPOINTS.tablet) return "tablet";
+  if (width >= BREAKPOINTS.tablet) return "desktop";
+  if (width >= BREAKPOINTS.mobile) return "tablet";
   return "mobile";
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#201 

## 📝 작업 내용

- 팀 생성 페이지 내 반응형 디자인 적용
- 팀 생성 요청을 mutation으로 변경 및 파일 분리
    - 팀 생성이 성공 / 실패 이후의 액션 추가
- create team form의 동작을 useCreateTeamForm hooks 로 분리
- 테스트 코드 작성

### 스크린샷 (선택)

적용된 모바일 디자인
<img width="322" height="403" alt="스크린샷 2026-04-10 오전 10 06 52" src="https://github.com/user-attachments/assets/f860c73a-86c0-4929-9da6-2e55faec5997" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
