### PR TITLE
Feat/#206: SoftButton 공통 컴포넌트 구현

### DIFF
--- a/src/components/common/SoftButton/SoftButton.stories.tsx
+++ b/src/components/common/SoftButton/SoftButton.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import SoftButton from "@/components/common/SoftButton";
+
+const meta: Meta<typeof SoftButton> = {
+  title: "Components/SoftButton",
+  component: SoftButton,
+  decorators: [
+    (Story) => (
+      <div className="w-[200px]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: { type: "radio" },
+      options: ["purple", "gray"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SoftButton>;
+
+// 기본버튼 : purple
+export const Default: Story = {
+  args: {
+    children: "보라색버튼",
+    variant: "purple",
+  },
+};
+
+// gray
+export const Gray: Story = {
+  args: {
+    children: "회색버튼",
+    variant: "gray",
+  },
+};
+
+// disabled
+export const Disabled: Story = {
+  args: {
+    children: "보라색버튼",
+    variant: "purple",
+    disabled: true,
+  },
+};

--- a/src/components/common/SoftButton/SoftButton.tsx
+++ b/src/components/common/SoftButton/SoftButton.tsx
@@ -1,0 +1,40 @@
+import { cva, VariantProps } from "class-variance-authority";
+import { ComponentProps } from "react";
+
+import { cn } from "@/utils/utils";
+
+const softButtonVariants = cva(
+  "text-label-1 rounded-[10px] font-semibold px-7 py-3 h-12 disabled:cursor-not-allowed disabled:bg-background-normal-alternative-2 disabled:text-gray-500 disabled:ring disabled:ring-gray-200 cursor-pointer hover:ring-1 hover:ring-blue-900 active:ring-1 active:ring-blue-900 disabled:pointer-events-none transition-colors",
+  {
+    variants: {
+      variant: {
+        purple: "bg-blue-100 text-blue-800 ",
+        gray: "bg-background-normal-alternative-2 text-gray-500 ring ring-gray-200 hover:text-blue-800 active:text-blue-800",
+      },
+    },
+    defaultVariants: {
+      variant: "purple",
+    },
+  },
+);
+
+interface SoftButtonProps
+  extends ComponentProps<"button">, VariantProps<typeof softButtonVariants> {}
+
+const SoftButton = ({
+  variant,
+  className,
+  children,
+  ...props
+}: SoftButtonProps) => {
+  return (
+    <button
+      className={cn(softButtonVariants({ variant }), className)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default SoftButton;

--- a/src/components/common/SoftButton/SoftButton.tsx
+++ b/src/components/common/SoftButton/SoftButton.tsx
@@ -4,12 +4,12 @@ import { ComponentProps } from "react";
 import { cn } from "@/utils/utils";
 
 const softButtonVariants = cva(
-  "text-label-1 rounded-[10px] font-semibold px-7 py-3 h-12 disabled:cursor-not-allowed disabled:bg-background-normal-alternative-2 disabled:text-gray-500 disabled:ring disabled:ring-gray-200 cursor-pointer hover:ring-1 hover:ring-blue-900 active:ring-1 active:ring-blue-900 disabled:pointer-events-none transition-colors",
+  "text-label-1 rounded-[10px] font-semibold px-7 py-3 h-12 disabled:cursor-not-allowed disabled:bg-background-normal-alternative-2 disabled:text-gray-400 disabled:ring disabled:ring-gray-200 cursor-pointer  disabled:pointer-events-none transition-colors",
   {
     variants: {
       variant: {
-        purple: "bg-blue-100 text-blue-800 ",
-        gray: "bg-background-normal-alternative-2 text-gray-500 ring ring-gray-200 hover:text-blue-800 active:text-blue-800",
+        purple: "bg-blue-100 text-blue-800 hover:bg-blue-200",
+        gray: "bg-background-normal-alternative-2 text-gray-400 ring-1 ring-gray-200 hover:ring-1 hover:bg-background-elevated-normal hover:text-gray-500 active:ring-1 active:ring-blue-900 active:text-blue-800",
       },
     },
     defaultVariants: {

--- a/src/components/common/SoftButton/index.ts
+++ b/src/components/common/SoftButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SoftButton";


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #206 

## 📝 작업 내용

  - `variant`: `purple`(파란 배경), `gray`(회색 배경) 2가지                                                                                                                                                                                                                                          
  - disabled: HTML `disabled` 속성 기반 처리 (`pointer-events-none` 포함)                                                                                                                                                                                                                            
  - Storybook stories 작성 (Default, Gray, Disabled)     
  - 디자인 변경으로 인한 수정작업 완료                                                                                                                                                                                                                                             
                                            

### 스크린샷 (선택)
<img width="1068" height="661" alt="스크린샷 2026-04-14 오전 11 51 25" src="https://github.com/user-attachments/assets/a421903f-edb5-4943-ad1b-4ef9f616e361" />


## 💬 리뷰 요구사항(선택)
> 마이페이지 적용 예정