### PR TITLE
feat(#226): 휴지통 API 연결 및 복구/삭제 기능 구현  

### DIFF
--- a/src/app/taskmate/trash/page.tsx
+++ b/src/app/taskmate/trash/page.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 
+import AsyncBoundary from "@/components/common/AsyncBoundary";
 import Trash from "@/components/trash";
 
 const TrashPage = () => {
   return (
     <div className="tablet:max-w-[560px] mx-auto w-full max-w-[335px]">
-      <Trash />
+      <AsyncBoundary>
+        <Trash />
+      </AsyncBoundary>
     </div>
   );
 };

--- a/src/components/common/SoftButton/SoftButton.stories.tsx
+++ b/src/components/common/SoftButton/SoftButton.stories.tsx
@@ -39,7 +39,7 @@ export const Default: Story = {
 export const Gray: Story = {
   args: {
     children: "회색버튼",
-    variant: "gray",
+    variant: "grayActive",
   },
 };
 

--- a/src/components/common/SoftButton/SoftButton.tsx
+++ b/src/components/common/SoftButton/SoftButton.tsx
@@ -9,7 +9,8 @@ const softButtonVariants = cva(
     variants: {
       variant: {
         purple: "bg-blue-100 text-blue-800 hover:bg-blue-200",
-        gray: "bg-background-normal-alternative-2 text-gray-400 ring-1 ring-gray-200 hover:ring-1 hover:bg-background-elevated-normal hover:text-gray-500 active:ring-1 active:ring-blue-900 active:text-blue-800",
+        grayActive:
+          "bg-background-normal-alternative-2  ring-1 ring-blue-900 text-blue-800",
       },
     },
     defaultVariants: {

--- a/src/components/trash/PersonalTrash/PersonalTrash.tsx
+++ b/src/components/trash/PersonalTrash/PersonalTrash.tsx
@@ -1,11 +1,29 @@
-import React from "react";
-
+"use client";
 import TrashEmpty from "@/components/trash/TrashEmpty";
 import TrashList from "@/components/trash/TrashList";
+import { trashQueries } from "@/constants/queryKeys/trash.queryKey";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 
 function PersonalTrash() {
-  const isEmpty = false;
-  return <div>{isEmpty ? <TrashEmpty /> : <TrashList />}</div>;
+  const { ref, data, isFetchingNextPage } = useInfiniteScroll(
+    trashQueries.personalTrashList(),
+  );
+
+  const items = data.pages.flatMap((page) => page.content);
+  const isEmpty = data.pages[0].totalElements === 0;
+  return (
+    <div>
+      {isEmpty ? (
+        <TrashEmpty />
+      ) : (
+        <TrashList
+          items={items}
+          bottomRef={ref}
+          isFetchingNextPage={isFetchingNextPage}
+        />
+      )}
+    </div>
+  );
 }
 
 export default PersonalTrash;

--- a/src/components/trash/TeamTrash/TeamTrash.tsx
+++ b/src/components/trash/TeamTrash/TeamTrash.tsx
@@ -1,11 +1,33 @@
 import React from "react";
 
-import TrashEmpty from "../TrashEmpty";
-import TrashList from "../TrashList";
+import TrashEmpty from "@/components/trash/TrashEmpty";
+import TrashList from "@/components/trash/TrashList";
+import { trashQueries } from "@/constants/queryKeys/trash.queryKey";
+import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 
-function TeamTrash() {
-  const isEmpty = true;
-  return <div>{isEmpty ? <TrashEmpty /> : <TrashList />}</div>;
+interface TeamTrashProp {
+  selectedTeamId: number;
+}
+
+function TeamTrash({ selectedTeamId }: TeamTrashProp) {
+  const { ref, data, isFetchingNextPage } = useInfiniteScroll(
+    trashQueries.teamTrashList(selectedTeamId),
+  );
+  const items = data.pages.flatMap((page) => page.content);
+  const isEmpty = data.pages[0].totalElements === 0;
+  return (
+    <div>
+      {isEmpty ? (
+        <TrashEmpty />
+      ) : (
+        <TrashList
+          items={items}
+          bottomRef={ref}
+          isFetchingNextPage={isFetchingNextPage}
+        />
+      )}
+    </div>
+  );
 }
 
 export default TeamTrash;

--- a/src/components/trash/TeamTrash/TeamTrashDropdown.tsx
+++ b/src/components/trash/TeamTrash/TeamTrashDropdown.tsx
@@ -2,17 +2,38 @@
 import { Icon } from "@/components/common/Icon";
 import { useDropdown } from "@/hooks/useDropdown";
 
-function TeamTrashDropdown() {
-  const options = [
-    "프론트엔드 1팀",
-    "기획 1팀",
-    "백엔드 2팀",
-    "프론테엔드프론테엔드프론테엔드프론테엔드",
-  ];
+interface Team {
+  teamId: number;
+  teamName: string;
+}
+
+interface TeamTrashDropdownProps {
+  teams: Team[];
+  selectedTeamId: number;
+  onSelect: (teamId: number) => void;
+}
+
+function TeamTrashDropdown({
+  teams,
+  selectedTeamId,
+  onSelect,
+}: TeamTrashDropdownProps) {
+  const options = teams.map((team) => team.teamName);
+  const selectedTeamName = teams.find(
+    (team) => team.teamId === selectedTeamId,
+  )?.teamName;
   const { isOpen, selected, toggle, selectItem, containerRef } = useDropdown(
     options,
-    options[0],
+    selectedTeamName,
   );
+
+  const handleSelect = (teamName: string) => {
+    const team = teams.find((team) => team.teamName === teamName);
+    if (!team) return;
+    onSelect(team.teamId);
+    selectItem(teamName);
+  };
+
   return (
     <div
       ref={containerRef}
@@ -32,13 +53,13 @@ function TeamTrashDropdown() {
       </button>
       {isOpen && (
         <ul className="bg-background-normal absolute w-full rounded-xl shadow-[0_4px_16px_-2px_rgba(0,0,0,0.1)]">
-          {options.map((option) => (
+          {teams.map((team) => (
             <li
-              key={option}
-              onClick={() => selectItem(option)}
+              key={team.teamId}
+              onClick={() => handleSelect(team.teamName)}
               className="text-label-neutral text-label-1 h-9 cursor-pointer truncate px-[11px] py-[5px] font-medium"
             >
-              {option}
+              {team.teamName}
             </li>
           ))}
         </ul>

--- a/src/components/trash/Trash.tsx
+++ b/src/components/trash/Trash.tsx
@@ -20,6 +20,9 @@ function Trash() {
 
   return (
     <div className="mt-20 flex w-full flex-col">
+      <h1 className="text-title-3 text-label-neutral tablet:block tablet:mt-0 mt-[106px] mb-8 hidden font-semibold">
+        삭제된 할 일
+      </h1>
       <div className="tablet:flex-row tablet:items-center tablet:justify-end flex flex-col">
         <div className="tablet:w-full w-[209px] pr-2">
           <TrashTabs

--- a/src/components/trash/Trash.tsx
+++ b/src/components/trash/Trash.tsx
@@ -1,13 +1,21 @@
 "use client";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
 
-import PersonalTrash from "./PersonalTrash";
-import TeamTrash from "./TeamTrash";
-import TeamTrashDropdown from "./TeamTrash/TeamTrashDropdown";
-import TrashTabs, { TrashTab } from "./TrashTabs";
+import PersonalTrash from "@/components/trash/PersonalTrash";
+import TeamTrash from "@/components/trash/TeamTrash";
+import TeamTrashDropdown from "@/components/trash/TeamTrash/TeamTrashDropdown";
+import TrashEmpty from "@/components/trash/TrashEmpty";
+import TrashTabs, { TrashTab } from "@/components/trash/TrashTabs";
+import { teamQueries } from "@/features/team/query/team.queryKey";
 
 function Trash() {
-  const [activeTab, setActiveTab] = useState<TrashTab>("team");
+  const [activeTab, setActiveTab] = useState<TrashTab>("personal");
+  const { data: teams } = useSuspenseQuery(teamQueries.all());
+  const [selectedTeamId, setSeletedTeamId] = useState<number | undefined>(
+    teams[0]?.teamId,
+  );
+
   return (
     <div className="mt-20 flex w-full flex-col">
       <div className="tablet:flex-row tablet:items-center tablet:justify-end flex flex-col">
@@ -17,11 +25,23 @@ function Trash() {
             onTabChange={setActiveTab}
           />
         </div>
-        {activeTab === "team" && <TeamTrashDropdown />}
+        {activeTab === "team" && selectedTeamId !== undefined && (
+          <TeamTrashDropdown
+            teams={teams}
+            selectedTeamId={selectedTeamId}
+            onSelect={setSeletedTeamId}
+          />
+        )}
       </div>
 
       <div className="w-full py-5">
-        {activeTab === "personal" ? <PersonalTrash /> : <TeamTrash />}
+        {activeTab === "personal" ? (
+          <PersonalTrash />
+        ) : selectedTeamId !== undefined ? (
+          <TeamTrash selectedTeamId={selectedTeamId} />
+        ) : (
+          <TrashEmpty />
+        )}
       </div>
     </div>
   );

--- a/src/components/trash/Trash.tsx
+++ b/src/components/trash/Trash.tsx
@@ -9,6 +9,8 @@ import TrashEmpty from "@/components/trash/TrashEmpty";
 import TrashTabs, { TrashTab } from "@/components/trash/TrashTabs";
 import { teamQueries } from "@/features/team/query/team.queryKey";
 
+import AsyncBoundary from "../common/AsyncBoundary";
+
 function Trash() {
   const [activeTab, setActiveTab] = useState<TrashTab>("personal");
   const { data: teams } = useSuspenseQuery(teamQueries.all());
@@ -35,13 +37,15 @@ function Trash() {
       </div>
 
       <div className="w-full py-5">
-        {activeTab === "personal" ? (
-          <PersonalTrash />
-        ) : selectedTeamId !== undefined ? (
-          <TeamTrash selectedTeamId={selectedTeamId} />
-        ) : (
-          <TrashEmpty />
-        )}
+        <AsyncBoundary>
+          {activeTab === "personal" ? (
+            <PersonalTrash />
+          ) : selectedTeamId !== undefined ? (
+            <TeamTrash selectedTeamId={selectedTeamId} />
+          ) : (
+            <TrashEmpty />
+          )}
+        </AsyncBoundary>
       </div>
     </div>
   );

--- a/src/components/trash/TrashItem/TrashItem.tsx
+++ b/src/components/trash/TrashItem/TrashItem.tsx
@@ -1,55 +1,51 @@
 import React from "react";
 
 import { Icon } from "@/components/common/Icon";
+import TrashBadge from "@/components/trash/TrashItem/TrashBadge";
+import { TrashItemData } from "@/features/trash/types/trash.types";
 
-import TrashBadge from "./TrashBadge";
+interface TrashItemProps extends TrashItemData {
+  isSelected: boolean;
+  onToggle: (id: number) => void;
+}
 
-const data = {
-  content: [
-    {
-      itemType: "GOAL",
-      id: 42,
-      deletedAt: "2026-04-15T02:17:29.290Z",
-      goalName: "이번 주 운동",
-      todoTitle: "러닝 30분",
-    },
-  ],
-  page: 0,
-  size: 7,
-  totalElements: 24,
-  totalPages: 4,
-};
-
-function TrashItem() {
+function TrashItem({ isSelected, onToggle, ...item }: TrashItemProps) {
   return (
     <div className="bg-background-normal flex items-center gap-4 rounded-2xl px-2.5 py-2">
       <div className="flex">
         <Icon
-          name={"InactiveFilledCheckBox"}
+          name={isSelected ? "ActiveFilledCheckBox" : "InactiveFilledCheckBox"}
           className="tablet:size-6 size-5 cursor-pointer"
-        />
-        <Icon
-          name={"ActiveFilledCheckBox"}
-          className="tablet:size-6 size-5 cursor-pointer"
+          onClick={() => onToggle(item.id)}
         />
       </div>
       <div className="flex min-w-0 flex-col">
-        <div className="flex min-w-0 items-center">
-          <TrashBadge type={"goal"} />
-          <TrashBadge type={"todo"} />
-          <span className="text-label-1 truncate font-semibold text-slate-800">
-            강의 내용을 Notion이나 문서에 요약 정리 강의
-          </span>
-        </div>
-        <div className="flex items-center gap-1.5">
-          <Icon
-            name="Paper"
-            className="size-3 text-gray-300"
-          />
-          <span className="text-label-2 font-medium text-gray-500">
-            디자인 시스템
-          </span>
-        </div>
+        {item.itemType === "GOAL" ? (
+          <div className="flex min-w-0 items-center gap-2">
+            <TrashBadge type={"goal"} />
+            <span className="text-label-1 truncate font-semibold text-slate-800">
+              {item.goalName}
+            </span>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <TrashBadge type={"todo"} />
+              <span className="text-label-1 truncate font-semibold text-slate-800">
+                {item.todoTitle}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Icon
+                name="Paper"
+                className="size-3 text-gray-300"
+              />
+              <span className="text-label-2 font-medium text-gray-500">
+                {item.goalName}
+              </span>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/trash/TrashItem/index.tsx
+++ b/src/components/trash/TrashItem/index.tsx
@@ -1,1 +1,2 @@
+export { default as TrashBadge } from "./TrashBadge";
 export { default } from "./TrashItem";

--- a/src/components/trash/TrashList/TrashList.tsx
+++ b/src/components/trash/TrashList/TrashList.tsx
@@ -1,32 +1,105 @@
-import React from "react";
+"use client";
+import React, { useState } from "react";
 
 import SoftButton from "@/components/common/SoftButton";
+import { useDeleteTrashMutation } from "@/features/trash/hooks/useDeleteTrashMutation";
+import { useRestoreTrashMutation } from "@/features/trash/hooks/useRestoreTrashMutation";
+import { TrashItemData } from "@/features/trash/types/trash.types";
 
 import TrashItem from "../TrashItem";
 
-function TrashList() {
+interface TrashListProps {
+  items: TrashItemData[];
+  bottomRef: React.RefObject<HTMLDivElement | null>;
+  isFetchingNextPage: boolean;
+}
+
+function TrashList({ items, bottomRef, isFetchingNextPage }: TrashListProps) {
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const { mutate: restoreMutate, isPending: isRestore } =
+    useRestoreTrashMutation();
+  const { mutate: deleteMutate, isPending: isDeleting } =
+    useDeleteTrashMutation();
+
+  const handleToggle = (id: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const handleSelectAll = () => {
+    if (selectedIds.size === items.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(items.map((item) => item.id)));
+    }
+  };
+
+  const getSelectedTrashItems = () => {
+    const selectedItems = items.filter((item) => selectedIds.has(item.id));
+    return {
+      goalIds: selectedItems
+        .filter((item) => item.itemType === "GOAL")
+        .map((item) => item.id),
+      todoIds: selectedItems
+        .filter((item) => item.itemType === "TODO")
+        .map((item) => item.id),
+    };
+  };
+  const handleRestore = () => {
+    restoreMutate(getSelectedTrashItems(), {
+      onSuccess: () => setSelectedIds(new Set()),
+    });
+  };
+
+  const handleDelete = () => {
+    deleteMutate(getSelectedTrashItems(), {
+      onSuccess: () => setSelectedIds(new Set()),
+    });
+  };
+
   return (
     <div>
-      <div className="bg-inverse-normal tablet:rounded-4xl tablet:h-[733px] tablet:pr-5 h-[646px] w-full rounded-3xl pt-4 pr-2 pl-5">
-        <TrashItem />
+      <div className="bg-inverse-normal tablet:rounded-4xl tablet:h-[733px] tablet:pr-5 h-[646px] w-full overflow-y-auto rounded-3xl pt-4 pr-2 pl-5">
+        {items.map((item) => (
+          <TrashItem
+            key={item.id}
+            isSelected={selectedIds.has(item.id)}
+            onToggle={handleToggle}
+            {...item}
+          />
+        ))}
+        <div ref={bottomRef}></div>
+        {isFetchingNextPage && (
+          <p className="text-caption-1 text-center text-gray-400">
+            불러오는 중
+          </p>
+        )}
       </div>
       <div className="tablet:mt-6 mt-5 flex w-full justify-between">
         <SoftButton
           variant={"purple"}
           className="tablet:w-[108px] flex w-[90px] items-center justify-center whitespace-nowrap"
+          onClick={handleSelectAll}
         >
           전체 선택
         </SoftButton>
         <div className="flex gap-2">
           <SoftButton
-            variant={"gray"}
+            variant={"grayActive"}
             className="tablet:w-[90px] w-20 whitespace-nowrap"
+            onClick={handleRestore}
+            disabled={selectedIds.size === 0 || isRestore || isDeleting}
           >
             복구
           </SoftButton>
           <SoftButton
-            variant={"gray"}
+            variant={"grayActive"}
             className="tablet:w-[90px] w-20 whitespace-nowrap"
+            onClick={handleDelete}
+            disabled={selectedIds.size === 0 || isRestore || isDeleting}
           >
             삭제
           </SoftButton>

--- a/src/constants/queryKeys/index.ts
+++ b/src/constants/queryKeys/index.ts
@@ -1,1 +1,2 @@
+export { trashQueries } from "@/constants/queryKeys/trash.queryKey";
 export { userQueries } from "@/constants/queryKeys/user.queryKey";

--- a/src/constants/queryKeys/trash.queryKey.ts
+++ b/src/constants/queryKeys/trash.queryKey.ts
@@ -1,0 +1,36 @@
+import { infiniteQueryOptions } from "@tanstack/react-query";
+
+import {
+  getPersonalTrashList,
+  getTeamTrashList,
+} from "@/features/trash/api/trash.api";
+
+import { STALE_TIME } from "../staleTime";
+
+const SIZE = 20;
+
+export const trashQueries = {
+  all: ["trash"] as const,
+
+  personalTrashList: () =>
+    infiniteQueryOptions({
+      queryKey: [...trashQueries.all, "personal"],
+      initialPageParam: 0,
+      queryFn: ({ pageParam }: { pageParam: number }) =>
+        getPersonalTrashList({ page: pageParam, size: SIZE }),
+      getNextPageParam: (lastPage, _, lastPageParam) =>
+        lastPage.page < lastPage.totalPages - 1 ? lastPageParam + 1 : undefined,
+      staleTime: STALE_TIME.MEDIUM,
+    }),
+
+  teamTrashList: (teamId: number) =>
+    infiniteQueryOptions({
+      queryKey: [...trashQueries.all, "team", teamId],
+      initialPageParam: 0,
+      queryFn: ({ pageParam }: { pageParam: number }) =>
+        getTeamTrashList(teamId, { page: pageParam, size: SIZE }),
+      getNextPageParam: (lastPage, _, lastPageParam) =>
+        lastPage.page < lastPage.totalPages - 1 ? lastPageParam + 1 : undefined,
+      staleTime: STALE_TIME.MEDIUM,
+    }),
+};

--- a/src/features/trash/api/trash.api.ts
+++ b/src/features/trash/api/trash.api.ts
@@ -1,0 +1,43 @@
+import { apiClient } from "@/lib/api/client";
+import { ApiResponse } from "@/lib/api/types";
+
+import { TrashActionParam, TrashListData } from "../types/trash.types";
+
+export async function deleteTrash(data: TrashActionParam) {
+  const res = await apiClient.delete<ApiResponse<string>>("/api/trash", {
+    body: data,
+  });
+  return res.data;
+}
+
+export async function restoreTrash(data: TrashActionParam) {
+  const res = await apiClient.post<ApiResponse<string>>(
+    "/api/trash/restore",
+    data,
+  );
+  return res.data;
+}
+
+export async function getPersonalTrashList(data: {
+  page?: number;
+  size?: number;
+}) {
+  const res = await apiClient.get<ApiResponse<TrashListData>>(
+    "/api/trash/personal",
+    { params: data },
+  );
+
+  return res.data;
+}
+
+export async function getTeamTrashList(
+  teamId: number,
+  data: { page?: number; size?: number },
+) {
+  const res = await apiClient.get<ApiResponse<TrashListData>>(
+    `/api/trash/teams/${teamId}`,
+    { params: data },
+  );
+
+  return res.data;
+}

--- a/src/features/trash/hooks/useDeleteTrashMutation/index.ts
+++ b/src/features/trash/hooks/useDeleteTrashMutation/index.ts
@@ -1,0 +1,1 @@
+export { useDeleteTrashMutation } from "./useDeleteTrashMutation";

--- a/src/features/trash/hooks/useDeleteTrashMutation/useDeleteTrashMutation.ts
+++ b/src/features/trash/hooks/useDeleteTrashMutation/useDeleteTrashMutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { deleteTrash } from "@/features/trash/api/trash.api";
+import { TrashActionParam } from "@/features/trash/types/trash.types";
+import { useToast } from "@/hooks/useToast";
+import { ApiError } from "@/lib/api/types";
+
+export const useDeleteTrashMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: (data: TrashActionParam) => deleteTrash(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["trash"] });
+      queryClient.invalidateQueries({ queryKey: ["personal", "goals"] });
+      queryClient.invalidateQueries({ queryKey: ["teams", "all"] });
+      queryClient.invalidateQueries({ queryKey: ["todo"] });
+      toast({ title: "삭제되었습니다", variant: "success" });
+    },
+    onError: (error: ApiError) => {
+      toast({
+        title: "삭제에 실패했습니다",
+        description: error.message,
+        variant: "error",
+      });
+    },
+  });
+};

--- a/src/features/trash/hooks/useRestoreTrashMutation/index.ts
+++ b/src/features/trash/hooks/useRestoreTrashMutation/index.ts
@@ -1,0 +1,1 @@
+export { useRestoreTrashMutation } from "./useRestoreTrashMutation";

--- a/src/features/trash/hooks/useRestoreTrashMutation/useRestoreTrashMutation.ts
+++ b/src/features/trash/hooks/useRestoreTrashMutation/useRestoreTrashMutation.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { restoreTrash } from "@/features/trash/api/trash.api";
+import { TrashActionParam } from "@/features/trash/types/trash.types";
+import { useToast } from "@/hooks/useToast";
+import { ApiError } from "@/lib/api/types";
+
+export const useRestoreTrashMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: (data: TrashActionParam) => restoreTrash(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["trash"] });
+      queryClient.invalidateQueries({ queryKey: ["personal", "goals"] });
+      queryClient.invalidateQueries({ queryKey: ["teams", "all"] });
+      queryClient.invalidateQueries({ queryKey: ["todo"] });
+
+      toast({ title: "복구되었습니다", variant: "success" });
+    },
+    onError: (error: ApiError) => {
+      toast({
+        title: "복구에 실패했습니다",
+        description: error.message,
+        variant: "error",
+      });
+    },
+  });
+};

--- a/src/features/trash/types/trash.types.ts
+++ b/src/features/trash/types/trash.types.ts
@@ -1,0 +1,21 @@
+export interface TrashItemData {
+  itemType: "GOAL" | "TODO";
+  id: number;
+  deleteAt: string;
+  teamName: string;
+  goalName: string;
+  todoTitle: string;
+}
+
+export interface TrashListData {
+  content: TrashItemData[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface TrashActionParam {
+  goalIds: number[];
+  todoIds: number[];
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Closes #226 

## 📝 작업 내용

  - infiniteQueryOptions 기반 개인/팀 휴지통 무한스크롤 조회 연결              
  - 팀 드롭다운 실제 팀 목록 연결 (teamId 기반 조회)                                                        
  - 체크박스 개별/전체 선택 기능 구현                                                                       
  - 복구/영구삭제 API 연결 (useRestoreTrashMutation, useDeleteTrashMutation)                                
  - 복구/삭제 성공 시 trash, goals, todo 쿼리 자동 갱신       
   
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

